### PR TITLE
Update RefdataBinding.groovy

### DIFF
--- a/src/main/groovy/com/k_int/web/toolkit/refdata/RefdataBinding.groovy
+++ b/src/main/groovy/com/k_int/web/toolkit/refdata/RefdataBinding.groovy
@@ -37,7 +37,7 @@ class RefdataBinding {
         if (propName == 'values' && RefdataCategory.isAssignableFrom(obj.class)) {
           
           if (!obj.id) {
-            final String norm_value = RefdataValue.normValue( data['label'] ?: data['value'] )
+            final String norm_value = RefdataValue.normValue( data['value'] ?: data['label'] )
             val = new RefdataValue(
               label: data['label'],
               value: norm_value


### PR DESCRIPTION
The current implementation doesn't allow configuration of the `value` when POSTing new RDCs. It seems like the order in the Elvis is backwards.