### PR TITLE
fix: Turned off DomainUtils caching

### DIFF
--- a/src/main/groovy/com/k_int/web/toolkit/utils/DomainUtils.groovy
+++ b/src/main/groovy/com/k_int/web/toolkit/utils/DomainUtils.groovy
@@ -191,7 +191,7 @@ public class DomainUtils {
               }
             
               currentDef = new InternalPropertyDefinition()
-              currentDef.cacheable = true
+              currentDef.cacheable = false // ERM-1931 -- this caching was causing issues with nested sortable properties of unsortable properties
               currentDef.domain = (type instanceof PersistentEntity || mappingContext.isPersistentEntity(type))
               currentDef.type   = (type instanceof PersistentEntity ? type.javaClass : type)
               currentDef.owner  = owner


### PR DESCRIPTION
Caching was causing sortable properties to identify as non-sortable when initially accessed through a non-sortable parent.

ERM-1931