### PR TITLE
feat: S3 secret environment variable

### DIFF
--- a/grails-app/domain/com/k_int/web/toolkit/settings/AppSetting.groovy
+++ b/grails-app/domain/com/k_int/web/toolkit/settings/AppSetting.groovy
@@ -40,7 +40,7 @@ public class AppSetting implements MultiTenant<AppSetting> {
 
   public static String getSettingValue(String section, String key) {
     String result = AppSetting.executeQuery('select coalesce(a.value, a.defValue) from AppSetting as a where a.section=:s and a.key=:k',
-                                            [s:section, k:key]).get(0);
+                                            [s:section, k:key])?[0]; // Swapped out .get(0) for ?[0] in order to empty-safe the process
     return result;
   }
 


### PR DESCRIPTION
Tweak to how S3 secret is read. First the AppSetting for S3SecretKey is read, if that is null then it searches for S3SecretEnvironmentVariable for a tenant level env var.

This will initially not be present in agreements/licenses, and so null/empty-safeing has been introduced to AppSetting.getSettingValue.

Finally if all above have returned null, fall back to GLOBAL_S3_SECRET_KEY

refs [ERM-3470](https://folio-org.atlassian.net/browse/ERM-3470)