### PR TITLE
feat: default 500 handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,9 @@ dependencies {
 
   // For some reason testImplementation for these two fails on gradlew check
 	compileOnly("org.grails:grails-gorm-testing-support")
-  compileOnly("org.spockframework:spock-core")
+	testImplementation "org.grails:grails-web-testing-support"
+
+	compileOnly("org.spockframework:spock-core")
 
   testImplementation("org.grails:grails-gorm-testing-support")
   testImplementation("org.spockframework:spock-core")

--- a/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
+++ b/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
@@ -17,7 +17,7 @@ class ErrorController {
       ex = ex.cause
     }
 
-    String message;
+    String message = "Uncaught Internal server error";
     int code = 500;
 
     // Individual error handling. If exception implements errorHandleable500 then we can get a String message from it

--- a/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
+++ b/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
@@ -1,6 +1,7 @@
 package com.k_int.web.toolkit
 
-import com.k_int.web.toolkit.error.errorHandleable500;
+import com.k_int.web.toolkit.error.handledException;
+import com.k_int.web.toolkit.error.ErrorHandle;
 
 import com.k_int.web.toolkit.grammar.SimpleLookupServiceException
 import grails.core.GrailsApplication
@@ -17,10 +18,13 @@ class ErrorController {
     }
 
     String message;
+    int code = 500;
 
     // Individual error handling. If exception implements errorHandleable500 then we can get a String message from it
-    if (ex instanceof errorHandleable500) {
-      message = ex.handle500Message()
+    if (ex instanceof handledException) {
+      ErrorHandle err = ex.handleException()
+      message = err.message;
+      code = err.code;
     }
 
 
@@ -31,10 +35,11 @@ class ErrorController {
       timestamp    : Instant.now().toString(),
       exception    : ex,
       includeStack : includeStack,
-      message      : message
+      message      : message,
+      code         : code
     ]
 
-    response.status = 500
+    response.status = code;
     // Explicitly render the standard '/error' view name.
     // Grails will look for /grails-app/views/error.gson first in the app,
     // then fall back to the one in the plugin.

--- a/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
+++ b/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
@@ -29,7 +29,7 @@ class ErrorController {
 
 
     // Fetch config property from the application using the plugin
-    Boolean includeStack = Boolean.valueOf(grailsApplication.config.getProperty('webtoolkit.endpoints.includeStackTraceFor500', String, 'false'))
+    Boolean includeStack = Boolean.valueOf(grailsApplication.config.getProperty('webtoolkit.endpoints.includeStackTrace', String, 'false'))
 
     def model = [
       timestamp    : Instant.now().toString(),

--- a/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
+++ b/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
@@ -1,0 +1,31 @@
+package com.k_int.web.toolkit
+
+import grails.core.GrailsApplication
+import java.time.Instant
+
+class ErrorController {
+
+  GrailsApplication grailsApplication // Inject GrailsApplication
+
+  def handle500() {
+    Throwable ex = request.getAttribute('javax.servlet.error.exception') ?: request.getAttribute('exception')
+    if (ex?.cause) {
+      ex = ex.cause
+    }
+
+    // Fetch config property from the application using the plugin
+    Boolean includeStack = Boolean.valueOf(grailsApplication.config.getProperty('webtoolkit.endpoints.includeStackTraceFor500', String, 'false'))
+
+    def model = [
+        timestamp: Instant.now().toString(),
+        exception         : ex,
+        includeStack : includeStack,
+    ]
+
+    response.status = 500
+    // Explicitly render the standard '/error' view name.
+    // Grails will look for /grails-app/views/error.gson first in the app,
+    // then fall back to the one in the plugin.
+    render(view: '/error', model: model)
+  }
+}

--- a/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
+++ b/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
@@ -1,5 +1,8 @@
 package com.k_int.web.toolkit
 
+import com.k_int.web.toolkit.error.errorHandleable500;
+
+import com.k_int.web.toolkit.grammar.SimpleLookupServiceException
 import grails.core.GrailsApplication
 import java.time.Instant
 
@@ -13,13 +16,22 @@ class ErrorController {
       ex = ex.cause
     }
 
+    String message;
+
+    // Individual error handling. If exception implements errorHandleable500 then we can get a String message from it
+    if (ex instanceof errorHandleable500) {
+      message = ex.handle500Message()
+    }
+
+
     // Fetch config property from the application using the plugin
     Boolean includeStack = Boolean.valueOf(grailsApplication.config.getProperty('webtoolkit.endpoints.includeStackTraceFor500', String, 'false'))
 
     def model = [
-        timestamp: Instant.now().toString(),
-        exception         : ex,
-        includeStack : includeStack,
+      timestamp    : Instant.now().toString(),
+      exception    : ex,
+      includeStack : includeStack,
+      message      : message
     ]
 
     response.status = 500

--- a/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
+++ b/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
@@ -29,7 +29,7 @@ class ErrorController {
 
 
     // Fetch config property from the application using the plugin
-    Boolean includeStack = Boolean.valueOf(grailsApplication.config.getProperty('webtoolkit.endpoints.includeStackTrace', String, 'false'))
+    Boolean includeStack = Boolean.valueOf(grailsApplication.config.getProperty('endpoints.include-stack-trace', String, 'false'))
 
     def model = [
       timestamp    : Instant.now().toString(),

--- a/grails-app/controllers/com/k_int/web/toolkit/UrlMappings.groovy
+++ b/grails-app/controllers/com/k_int/web/toolkit/UrlMappings.groovy
@@ -3,6 +3,8 @@ package com.k_int.web.toolkit
 class UrlMappings {
 
   static mappings = {
+    "500"(controller: 'error' , action: "handle500") // This is a _default_ but can be overridden per module
+
     "/kiwt/config/$extended?" (controller: 'config' , action: "resources")
     "/kiwt/config/schema/$type" (controller: 'config' , action: "schema")
     "/kiwt/config/schema/embedded/$type" (controller: 'config' , action: "schemaEmbedded")

--- a/grails-app/views/error.gson
+++ b/grails-app/views/error.gson
@@ -2,15 +2,26 @@ model {
 	String timestamp
 	Throwable exception
 	Boolean includeStack
+	String message // Message can now be passed in
 }
+
+// We handle individual exception handling above, in the controller
 
 json {
   error 500
   timestamp timestamp
 
   if (includeStack && exception) {
-    message "${exception}"
+    if (message) {
+      exception "${exception}"
+      message message
+    } else {
+      message "${exception}"
+    }
+
     stackTrace (exception.stackTrace.collect { "${it}" })
+  } else if (message) {
+    message message
   } else {
     message "Uncaught Internal server error"
   }

--- a/grails-app/views/error.gson
+++ b/grails-app/views/error.gson
@@ -3,12 +3,13 @@ model {
 	Throwable exception
 	Boolean includeStack
 	String message // Message can now be passed in
+	int code
 }
 
 // We handle individual exception handling above, in the controller
 
 json {
-  error 500
+  error code
   timestamp timestamp
 
   if (includeStack && exception) {

--- a/grails-app/views/error.gson
+++ b/grails-app/views/error.gson
@@ -1,0 +1,17 @@
+model {
+	String timestamp
+	Throwable exception
+	Boolean includeStack
+}
+
+json {
+  error 500
+  timestamp timestamp
+
+  if (includeStack && exception) {
+    message "${exception}"
+    stackTrace (exception.stackTrace.collect { "${it}" })
+  } else {
+    message "Uncaught Internal server error"
+  }
+}

--- a/grails-app/views/error.gson
+++ b/grails-app/views/error.gson
@@ -21,9 +21,7 @@ json {
     }
 
     stackTrace (exception.stackTrace.collect { "${it}" })
-  } else if (message) {
-    message message
   } else {
-    message "Uncaught Internal server error"
+    message message
   }
 }

--- a/src/main/groovy/com/k_int/web/toolkit/error/ErrorHandle.java
+++ b/src/main/groovy/com/k_int/web/toolkit/error/ErrorHandle.java
@@ -1,0 +1,15 @@
+package com.k_int.web.toolkit.error;
+
+public class ErrorHandle {
+  public int code;
+  public String message;
+
+  public ErrorHandle(String msg, int code) {
+    this.code = code;
+    this.message = msg;
+  }
+
+  public ErrorHandle(String msg) {
+    this(msg, 500);
+  }
+};

--- a/src/main/groovy/com/k_int/web/toolkit/error/errorHandleable500.java
+++ b/src/main/groovy/com/k_int/web/toolkit/error/errorHandleable500.java
@@ -1,0 +1,5 @@
+package com.k_int.web.toolkit.error;
+
+public interface errorHandleable500 {
+    String handle500Message();
+}

--- a/src/main/groovy/com/k_int/web/toolkit/error/errorHandleable500.java
+++ b/src/main/groovy/com/k_int/web/toolkit/error/errorHandleable500.java
@@ -1,5 +1,13 @@
 package com.k_int.web.toolkit.error;
 
+// A simple interface allowing 500 error message handling per exception
+/*
+ * Any exception which is not caught in a request context will result in an "Uncaught Internal server error"
+ * message on the response (for security reasons). If it is relatively common to see a certain exception
+ * in a certain service call, but not worth wrapping each expected usage of that service in a try/catch at the
+ * request level, instead an exception implementing this can be thrown, and `handle500Message` will be used to
+ * provide context in the response.
+ */
 public interface errorHandleable500 {
     String handle500Message();
 }

--- a/src/main/groovy/com/k_int/web/toolkit/error/handledException.java
+++ b/src/main/groovy/com/k_int/web/toolkit/error/handledException.java
@@ -1,13 +1,15 @@
 package com.k_int.web.toolkit.error;
 
-// A simple interface allowing 500 error message handling per exception
+// A simple interface allowing error message handling per exception
 /*
  * Any exception which is not caught in a request context will result in an "Uncaught Internal server error"
  * message on the response (for security reasons). If it is relatively common to see a certain exception
  * in a certain service call, but not worth wrapping each expected usage of that service in a try/catch at the
  * request level, instead an exception implementing this can be thrown, and `handle500Message` will be used to
  * provide context in the response.
+ *
+ * Returns an ErrorHandle, with a HttpCode and message
  */
-public interface errorHandleable500 {
-    String handle500Message();
+public interface handledException {
+    ErrorHandle handleException();
 }

--- a/src/main/groovy/com/k_int/web/toolkit/grammar/SimpleLookupServiceException.groovy
+++ b/src/main/groovy/com/k_int/web/toolkit/grammar/SimpleLookupServiceException.groovy
@@ -1,0 +1,45 @@
+package com.k_int.web.toolkit.grammar
+
+import com.k_int.web.toolkit.error.errorHandleable500
+
+class SimpleLookupServiceException extends Exception implements errorHandleable500 {
+  public static final Long GENERIC_ERROR = 0L
+  public static final Long INVALID_PROPERTY = 1L
+
+  final Long code
+
+  final String contextString
+
+  SimpleLookupServiceException(String errorMessage, Long code, String contextString) {
+    super(errorMessage)
+    this.code = code
+    this.contextString = contextString
+  }
+
+  SimpleLookupServiceException(String errorMessage, Long code) {
+    SimpleLookupServiceException(errorMessage, code, null)
+  }
+
+  SimpleLookupServiceException(String errorMessage) {
+    SimpleLookupServiceException(errorMessage, GENERIC_ERROR)
+  }
+
+  String handle500Message() {
+    String msg500
+    switch(code) {
+      case INVALID_PROPERTY:
+        msg500 = "Failure in SimpleLookupService. Invalid property: ${contextString}"
+        break
+      case GENERIC_ERROR:
+      default:
+        if (contextString) {
+          msg500 = "Failure in SimpleLookupService. Context: ${contextString}"
+        } else {
+          msg500 = "Failure in SimpleLookupService"
+        }
+        break
+    }
+
+    return msg500
+  }
+}

--- a/src/main/groovy/com/k_int/web/toolkit/grammar/SimpleLookupServiceException.groovy
+++ b/src/main/groovy/com/k_int/web/toolkit/grammar/SimpleLookupServiceException.groovy
@@ -7,24 +7,23 @@ class SimpleLookupServiceException extends Exception implements errorHandleable5
   public static final Long INVALID_PROPERTY = 1L
 
   final Long code
-
   final String contextString
 
-  SimpleLookupServiceException(String errorMessage, Long code, String contextString) {
+  public SimpleLookupServiceException(String errorMessage, Long code, String contextString) {
     super(errorMessage)
     this.code = code
     this.contextString = contextString
   }
 
-  SimpleLookupServiceException(String errorMessage, Long code) {
+  public SimpleLookupServiceException(String errorMessage, Long code) {
     SimpleLookupServiceException(errorMessage, code, null)
   }
 
-  SimpleLookupServiceException(String errorMessage) {
+  public SimpleLookupServiceException(String errorMessage) {
     SimpleLookupServiceException(errorMessage, GENERIC_ERROR)
   }
 
-  String handle500Message() {
+  public String handle500Message() {
     String msg500
     switch(code) {
       case INVALID_PROPERTY:

--- a/src/main/groovy/com/k_int/web/toolkit/grammar/SimpleLookupServiceException.groovy
+++ b/src/main/groovy/com/k_int/web/toolkit/grammar/SimpleLookupServiceException.groovy
@@ -1,8 +1,10 @@
 package com.k_int.web.toolkit.grammar
 
-import com.k_int.web.toolkit.error.errorHandleable500
+import com.k_int.web.toolkit.error.handledException
+import com.k_int.web.toolkit.error.ErrorHandle
 
-class SimpleLookupServiceException extends Exception implements errorHandleable500 {
+
+class SimpleLookupServiceException extends Exception implements handledException {
   public static final Long GENERIC_ERROR = 0L
   public static final Long INVALID_PROPERTY = 1L
 
@@ -23,22 +25,22 @@ class SimpleLookupServiceException extends Exception implements errorHandleable5
     SimpleLookupServiceException(errorMessage, GENERIC_ERROR)
   }
 
-  public String handle500Message() {
-    String msg500
+  public ErrorHandle handleException() {
+    ErrorHandle handle;
     switch(code) {
       case INVALID_PROPERTY:
-        msg500 = "Failure in SimpleLookupService. Invalid property: ${contextString}"
+        handle = new ErrorHandle("Failure in SimpleLookupService. Invalid property: ${contextString}", 400)
         break
       case GENERIC_ERROR:
       default:
         if (contextString) {
-          msg500 = "Failure in SimpleLookupService. Context: ${contextString}"
+          handle = new ErrorHandle("Failure in SimpleLookupService. Context: ${contextString}")
         } else {
-          msg500 = "Failure in SimpleLookupService"
+          handle = new ErrorHandle("Failure in SimpleLookupService")
         }
         break
     }
 
-    return msg500
+    return handle
   }
 }

--- a/src/main/groovy/com/k_int/web/toolkit/grammar/SimpleLookupServiceListenerWtk.groovy
+++ b/src/main/groovy/com/k_int/web/toolkit/grammar/SimpleLookupServiceListenerWtk.groovy
@@ -404,7 +404,9 @@ class SimpleLookupServiceListenerWtk implements SimpleLookupWtkListener {
   }	
 	
 	private void addCriterion ( final String subjectExpr, final InternalPropertyDefinition rootPropDef, final Token op, final String value = null, boolean invertOp = false ) {
-		
+		if (rootPropDef == null) {
+      throw new SimpleLookupServiceException("Cannot add criterion for subject: ${subjectExpr}", 1, subjectExpr);
+    }
 		InternalPropertyDefinition propDef = rootPropDef
 		final String partialPathBySubQuery = propDef.subQuery
 		String subject = subjectExpr

--- a/src/main/groovy/com/k_int/web/toolkit/grammar/SimpleLookupServiceListenerWtk.groovy
+++ b/src/main/groovy/com/k_int/web/toolkit/grammar/SimpleLookupServiceListenerWtk.groovy
@@ -405,7 +405,11 @@ class SimpleLookupServiceListenerWtk implements SimpleLookupWtkListener {
 	
 	private void addCriterion ( final String subjectExpr, final InternalPropertyDefinition rootPropDef, final Token op, final String value = null, boolean invertOp = false ) {
 		if (rootPropDef == null) {
-      throw new SimpleLookupServiceException("Cannot add criterion for subject: ${subjectExpr}", 1, subjectExpr);
+      throw new SimpleLookupServiceException(
+          "Cannot add criterion for subject: ${subjectExpr}",
+          SimpleLookupServiceException.INVALID_PROPERTY,
+          subjectExpr
+      );
     }
 		InternalPropertyDefinition propDef = rootPropDef
 		final String partialPathBySubQuery = propDef.subQuery

--- a/src/test/groovy/com/k_int/web/toolkit/ErrorControllerSpec.groovy
+++ b/src/test/groovy/com/k_int/web/toolkit/ErrorControllerSpec.groovy
@@ -25,39 +25,6 @@ class ErrorControllerSpec extends Specification implements ControllerUnitTest<Er
     }
   }
 
-  /*@Unroll
-  def 'handle500 should render expected /error view with handledException'(
-      Class<? extends Exception> exClass,
-      String errMessage,
-      boolean handledException
-  ) {
-    given: 'A handledException is present in request attributes'
-      def ex = new ErrorControllerSpecException("Something went wrong")
-      controller.request.setAttribute('javax.servlet.error.exception', ex)
-
-    and: 'grailsApplication config has include-stack-trace = true'
-      def mockGrailsApp = Mock(GrailsApplication)
-
-      mockGrailsApp.getConfig() >> Mock(Config) {
-        getProperty('endpoints.include-stack-trace', String, 'false') >> 'true'
-      }
-      controller.grailsApplication = mockGrailsApp
-
-    when: 'Calling handle500'
-      controller.handle500()
-
-    then: 'The /error view is rendered with correct model'
-      view == '/error'
-      model.message == 'ErrorControllerSpecException thrown'
-      model.code == 308
-      model.exception == ex
-      model.includeStack == true
-      response.status == 308
-    where:
-      exClass | errMessage | handledException | expectedMessage | expectedCode
-      ErrorControllerSpecException.class | "ErrorControllerSpecException thrown" | true | "ErrorControllerSpecException thrown" | 308
-
-  }*/
   @Unroll
   def "handle500 with #exceptionType.simpleName and config.includeStack=#includeStack should render expected values"() {
     given: 'An exception in request attributes'

--- a/src/test/groovy/com/k_int/web/toolkit/ErrorControllerSpec.groovy
+++ b/src/test/groovy/com/k_int/web/toolkit/ErrorControllerSpec.groovy
@@ -1,0 +1,106 @@
+package com.k_int.web.toolkit
+
+import grails.config.Config
+import spock.lang.Specification
+
+import grails.testing.web.controllers.ControllerUnitTest
+import grails.core.GrailsApplication
+
+import com.k_int.web.toolkit.error.handledException;
+import com.k_int.web.toolkit.error.ErrorHandle
+import spock.lang.Unroll;
+
+class ErrorControllerSpec extends Specification implements ControllerUnitTest<ErrorController> {
+  class ErrorControllerSpecException extends Exception implements handledException {
+    public ErrorControllerSpecException(String errorMessage) {
+      super(errorMessage)
+    }
+
+    public ErrorHandle handleException() {
+      ErrorHandle handle;
+
+      handle = new ErrorHandle("ErrorControllerSpecException thrown: ${this.message}", 308)
+
+      return handle
+    }
+  }
+
+  /*@Unroll
+  def 'handle500 should render expected /error view with handledException'(
+      Class<? extends Exception> exClass,
+      String errMessage,
+      boolean handledException
+  ) {
+    given: 'A handledException is present in request attributes'
+      def ex = new ErrorControllerSpecException("Something went wrong")
+      controller.request.setAttribute('javax.servlet.error.exception', ex)
+
+    and: 'grailsApplication config has include-stack-trace = true'
+      def mockGrailsApp = Mock(GrailsApplication)
+
+      mockGrailsApp.getConfig() >> Mock(Config) {
+        getProperty('endpoints.include-stack-trace', String, 'false') >> 'true'
+      }
+      controller.grailsApplication = mockGrailsApp
+
+    when: 'Calling handle500'
+      controller.handle500()
+
+    then: 'The /error view is rendered with correct model'
+      view == '/error'
+      model.message == 'ErrorControllerSpecException thrown'
+      model.code == 308
+      model.exception == ex
+      model.includeStack == true
+      response.status == 308
+    where:
+      exClass | errMessage | handledException | expectedMessage | expectedCode
+      ErrorControllerSpecException.class | "ErrorControllerSpecException thrown" | true | "ErrorControllerSpecException thrown" | 308
+
+  }*/
+  @Unroll
+  def "handle500 with #exceptionType.simpleName and config.includeStack=#includeStack should render expected values"() {
+    given: 'An exception in request attributes'
+      def ex = exceptionInstance
+      controller.request.setAttribute('javax.servlet.error.exception', ex)
+
+    and: 'grailsApplication config is mocked'
+      def mockGrailsApp = Mock(GrailsApplication)
+      mockGrailsApp.getConfig() >> Mock(Config) {
+        getProperty('endpoints.include-stack-trace', String, 'false') >> includeStack
+      }
+      controller.grailsApplication = mockGrailsApp
+
+    when: 'Calling handle500'
+      controller.handle500()
+
+    then: 'The expected values are rendered'
+      view == '/error'
+      model.message == expectedMessage
+      model.code == expectedCode
+      model.exception == ex
+      model.includeStack.toString() == includeStack // convert to string to match exact config
+      response.status == expectedCode
+
+    where:
+    // Combine all possibilities
+    [exceptionType, exceptionInstance, expectedMessage, expectedCode, includeStack] << [
+      [
+        exceptionType    : ErrorControllerSpecException,
+        exceptionInstance: new ErrorControllerSpecException("boom"),
+        expectedMessage  : "ErrorControllerSpecException thrown: boom",
+        expectedCode     : 308
+      ],
+      [
+        exceptionType    : RuntimeException,
+        exceptionInstance: new RuntimeException("oops"),
+        expectedMessage  : "Uncaught Internal server error",
+        expectedCode     : 500
+      ]
+    ].collectMany { base ->
+      ['true', 'false'].collect { stack ->
+        [base.exceptionType, base.exceptionInstance, base.expectedMessage, base.expectedCode, stack]
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Error controller

Added a centralised ErrorController and routing, so that individual modules no longer _need_ to implement their own error handling (although they can to override)

## Configuration
In addition, include a new grails config option: 
```
endpoints:
  include-stack-trace: true
```
This defaults to false both in the application example above, but also in the service itself, so that to turn stacktraces on for a module the way to do that is EITHER a change as above in the module application.yml, or running with `ENDPOINTS_INCLUDE_STACK_TRACE=true` environment variable

## Response
This default will turn off all stacktraces and most messages by default from 500 errors generated by Exceptions falling through to the grails request try/catch. Instead the response will look like:
```
{
  "error": 500,
  "timestamp": "2025-05-06T15:05:47.565059482Z",
  "message": "Uncaught Internal server error"
}
```

This includes a timestamp for easier debugging, and flattens any uncaught errors into a generic message by default to avoid any potential security issues arising from knowlegde of which libraries are throwing which Exceptions.


## handledException
This update also includes an interface `handledException`, which custom Exceptions can implement, including a special handling method to return a sanitised error response string in common situations. It is not always feasible for common errors to be caught in all controller cases.

Exceptions implementing this interface can also specify OTHER Http codes for responses if relevant.

### Example
SimpleLookupService is used by every single module for nearly every single endpoint. In order to  provide useful information on errors happening in this service it is not feasible that every single implementing endpoint be wrapped in a try/catch.

Instead, a new Exception `SimpleLookupServiceException` was created implementing `handledException`.
When the SimpleLookupService throws this exception the user can instead then see error responses such as:

```
{
  "error": 400,
  "timestamp": "2025-05-06T15:11:59.175733475Z",
  "message": "Failure in SimpleLookupService. Invalid property: nonsense"
}
```

This is currently the only case that has been set up to use the new Exception


This PR refs [ERM-3292](https://folio-org.atlassian.net/browse/ERM-3292)