### PR TITLE
ERM-3759: Add missing primary keys in web toolkit

### DIFF
--- a/src/migrations/wtk/multi-value-custprops.feat.groovy
+++ b/src/migrations/wtk/multi-value-custprops.feat.groovy
@@ -111,4 +111,47 @@ databaseChangeLog = {
       constraintName: "FKbklek969hy5ykdxsp2nf3t5fl", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id",
       referencedTableName: "custom_property_multi_text", validate: "true")
   }
+
+  // Add primary keys (ERM-3759)
+  changeSet(author: "mchaib (manual)", id: "20250703-0953-001") {
+    preConditions(onFail: 'MARK_RAN') {
+      not { primaryKeyExists(tableName: 'custom_property_multi_blob_value') }
+    }
+    addPrimaryKey(tableName: "custom_property_multi_blob_value", columnNames: "custom_property_multi_blob_id", constraintName: "custom_property_multi_blob_valuePK")
+  }
+
+  changeSet(author: "mchaib (manual)", id: "20250703-0953-002") {
+    preConditions(onFail: 'MARK_RAN') {
+      not { primaryKeyExists(tableName: 'custom_property_multi_decimal_value') }
+    }
+    addPrimaryKey(tableName: "custom_property_multi_decimal_value", columnNames: "custom_property_multi_decimal_id", constraintName: "custom_property_multi_decimal_valuePK")
+  }
+
+  changeSet(author: "mchaib (manual)", id: "20250703-0953-003") {
+    preConditions(onFail: 'MARK_RAN') {
+      not { primaryKeyExists(tableName: 'custom_property_multi_integer_value') }
+    }
+    addPrimaryKey(tableName: "custom_property_multi_integer_value", columnNames: "custom_property_multi_integer_id", constraintName: "custom_property_multi_integer_valuePK")
+  }
+
+  changeSet(author: "mchaib (manual)", id: "20250703-0953-004") {
+    preConditions(onFail: 'MARK_RAN') {
+      not { primaryKeyExists(tableName: 'custom_property_multi_local_date_value') }
+    }
+    addPrimaryKey(tableName: "custom_property_multi_local_date_value", columnNames: "custom_property_multi_local_date_id", constraintName: "custom_property_multi_local_date_valuePK")
+  }
+
+  changeSet(author: "mchaib (manual)", id: "20250703-0953-005") {
+    preConditions(onFail: 'MARK_RAN') {
+      not { primaryKeyExists(tableName: 'custom_property_multi_refdata_refdata_value') }
+    }
+    addPrimaryKey(tableName: "custom_property_multi_refdata_refdata_value", columnNames: "custom_property_multi_refdata_value_id", constraintName: "custom_property_multi_refdata_refdata_valuePK")
+  }
+
+  changeSet(author: "mchaib (manual)", id: "20250703-0953-006") {
+    preConditions(onFail: 'MARK_RAN') {
+      not { primaryKeyExists(tableName: 'custom_property_multi_text_value') }
+    }
+    addPrimaryKey(tableName: "custom_property_multi_text_value", columnNames: "custom_property_multi_text_id", constraintName: "custom_property_multi_text_valuePK")
+  }
 }


### PR DESCRIPTION
We noticed these tables (listed below) from web-toolkit were missing primary keys when investigating mod-agreements. 

To test this PR works I:
- Ran ./gradlew clean and ./gradlew publishToMavenLocal on the main branches of web-toolkit-ce and grails-okapi locally. 
- Uncommented mavenLocal()'s in the build.gradle of mod-agreements (on main). 
- Ran mod-agreements and dropped tenant. Checked which tables were missing primary keys in PgAdmin (it was the tables in list below).
- Made a new branch for this PR with the changes to web-toolkit-ce: Add primary keys in the src/migrations/wtk/multi-value-custprops.feat.groovy migartion file.
- Switched to the branch and ran ./gradlew clean and ./gradlew publishToMavenLocal.
- Stopped the mod-agreements application and ran ./gradlew clean on mod-agreements.
- Restarted mod-agreements and then ran the trigger-migrations.sh script. 
- Checked on PgAdmin that all the custom_property tables now have primary keys.

Tables with new primary keys added:
"custom_property_multi_blob_value"
"custom_property_multi_decimal_value"
"custom_property_multi_integer_value"
"custom_property_multi_local_date_value"
"custom_property_multi_refdata_refdata_value"
"custom_property_multi_text_value"
