### PR TITLE
ERM-3770: Error controller can cause a fatal infinite loop

### DIFF
--- a/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
+++ b/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
@@ -5,44 +5,68 @@ import com.k_int.web.toolkit.error.ErrorHandle;
 
 import com.k_int.web.toolkit.grammar.SimpleLookupServiceException
 import grails.core.GrailsApplication
+import groovy.util.logging.Slf4j
+
 import java.time.Instant
 
+@Slf4j
 class ErrorController {
 
   GrailsApplication grailsApplication // Inject GrailsApplication
+//  Boolean includeStack = false;
 
   def handle500() {
-    Throwable ex = request.getAttribute('javax.servlet.error.exception') ?: request.getAttribute('exception')
-    if (ex?.cause) {
-      ex = ex.cause
+    try {
+      Throwable ex = request.getAttribute('javax.servlet.error.exception') ?: request.getAttribute('exception')
+      if (ex?.cause) {
+        ex = ex.cause
+      }
+
+      throw new Exception("Oops")
+
+      String message = "Uncaught Internal server error";
+      int code = 500;
+
+      // Individual error handling. If exception implements errorHandleable500 then we can get a String message from it
+      if (ex instanceof handledException) {
+        ErrorHandle err = ex.handleException()
+        message = err.message;
+        code = err.code;
+      }
+
+
+      // Fetch config property from the application using the plugin
+      Boolean includeStack = Boolean.valueOf(grailsApplication.config.getProperty('endpoints.include-stack-trace', String, 'false'))
+
+      def model = [
+        timestamp   : Instant.now().toString(),
+        exception   : ex,
+        includeStack: includeStack,
+        message     : message,
+        code        : code
+      ]
+
+      response.status = code;
+      // Explicitly render the standard '/error' view name.
+      // Grails will look for /grails-app/views/error.gson first in the app,
+      // then fall back to the one in the plugin.
+      render(view: '/error', model: model)
+    } catch (Throwable t) {
+      // try to get the original exception
+      Throwable originalException = request.getAttribute('javax.servlet.error.exception')
+      log.error("Exception occurred within the WebToolkit ErrorController. The original exception being handled was [{}].", originalException?.message, t)
+
+      response.status = 500
+      response.setContentType('application/json')
+      response.writer << """
+        {
+          "timestamp": "${Instant.now().toString()}",
+          "status": 500,
+          "error": "Internal Server Error",
+          "message": "An error occurred while attempting to handle another error. Please check the logs for details.",
+          "path": "${request.forwardURI}"
+        }
+      """.stripIndent()
     }
-
-    String message = "Uncaught Internal server error";
-    int code = 500;
-
-    // Individual error handling. If exception implements errorHandleable500 then we can get a String message from it
-    if (ex instanceof handledException) {
-      ErrorHandle err = ex.handleException()
-      message = err.message;
-      code = err.code;
-    }
-
-
-    // Fetch config property from the application using the plugin
-    Boolean includeStack = Boolean.valueOf(grailsApplication.config.getProperty('endpoints.include-stack-trace', String, 'false'))
-
-    def model = [
-      timestamp    : Instant.now().toString(),
-      exception    : ex,
-      includeStack : includeStack,
-      message      : message,
-      code         : code
-    ]
-
-    response.status = code;
-    // Explicitly render the standard '/error' view name.
-    // Grails will look for /grails-app/views/error.gson first in the app,
-    // then fall back to the one in the plugin.
-    render(view: '/error', model: model)
   }
 }

--- a/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
+++ b/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
@@ -13,7 +13,6 @@ import java.time.Instant
 class ErrorController {
 
   GrailsApplication grailsApplication // Inject GrailsApplication
-//  Boolean includeStack = false;
 
   def handle500() {
     try {

--- a/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
+++ b/grails-app/controllers/com/k_int/web/toolkit/ErrorController.groovy
@@ -21,8 +21,6 @@ class ErrorController {
         ex = ex.cause
       }
 
-      throw new Exception("Oops")
-
       String message = "Uncaught Internal server error";
       int code = 500;
 
@@ -55,6 +53,7 @@ class ErrorController {
       Throwable originalException = request.getAttribute('javax.servlet.error.exception')
       log.error("Exception occurred within the WebToolkit ErrorController. The original exception being handled was [{}].", originalException?.message, t)
 
+      // Respond with minimal response
       response.status = 500
       response.setContentType('application/json')
       response.writer << """


### PR DESCRIPTION
Adds a try-catch around the contents of the handle500() method. Tested successfully by hitting an endpoint that throws and exception and manually creating an exception inside the error controller. I wasn't sure how to re-create the OkapiInterceptor throwing an error, but if the exception is still routed to the ErrorController then the try-catch should handle it in the same way and prevent an infinite loop. 