### PR TITLE
ERM-4000 - Web-toolkit - Support S3 access with implicit AWS role authorization

### DIFF
--- a/grails-app/services/com/k_int/web/toolkit/files/FileUploadService.groovy
+++ b/grails-app/services/com/k_int/web/toolkit/files/FileUploadService.groovy
@@ -1,18 +1,14 @@
 package com.k_int.web.toolkit.files
 
+import io.minio.credentials.IamAwsProvider
+import io.minio.credentials.Provider
+import io.minio.credentials.StaticProvider
 import org.springframework.web.multipart.MultipartFile
 import com.k_int.web.toolkit.settings.AppSetting
 
-import io.minio.BucketExistsArgs;
-import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
-import io.minio.UploadObjectArgs;
 import io.minio.PutObjectArgs;
 import io.minio.GetObjectArgs;
-import io.minio.errors.MinioException;
-import java.io.IOException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import org.hibernate.Hibernate;
 
 class FileUploadService {
@@ -100,13 +96,11 @@ class FileUploadService {
 
     log.debug("s3FileObjectFromStream ${s3_endpoint} ${s3_access_key} ${s3_secret_key} ${s3_bucket} ${s3_region}");
 
-    // Create a minioClient with the MinIO server playground, its access key and secret key.
+    // Create a minioClient with the MinIO server playground, its credentials provider.
     // See https://blogs.ashrithgn.com/spring-boot-uploading-and-downloading-file-from-minio-object-store/
-    MinioClient minioClient =
-          MinioClient.builder()
-              .endpoint(s3_endpoint)
-              .credentials(s3_access_key, s3_secret_key)
-              .build();
+    Provider provider = resolveCredentialsProvider(s3_access_key, s3_secret_key);
+    log.info("{} MinIO credentials provider created.", provider.getClass().getSimpleName());
+    MinioClient minioClient = buildMinioClient(s3_endpoint, provider);
 
      minioClient.putObject(
        PutObjectArgs.builder()
@@ -241,13 +235,11 @@ class FileUploadService {
     String s3_bucket = AppSetting.getSettingValue('fileStorage', 'S3BucketName');
     String s3_region = AppSetting.getSettingValue('fileStorage', 'S3BucketRegion') ?: 'us-east-1';
 
-    // Create a minioClient with the MinIO server playground, its access key and secret key.
+    // Create a minioClient with the MinIO server playground, its credentials provider.
     // See https://blogs.ashrithgn.com/spring-boot-uploading-and-downloading-file-from-minio-object-store/
-    MinioClient minioClient =
-          MinioClient.builder()
-              .endpoint(s3_endpoint)
-              .credentials(s3_access_key, s3_secret_key)
-              .build();
+    Provider provider = resolveCredentialsProvider(s3_access_key, s3_secret_key);
+    log.info("{} MinIO credentials provider created.", provider.getClass().getSimpleName());
+    MinioClient minioClient = buildMinioClient(s3_endpoint, provider);
 
     log.debug("Attempt to retrieve file ${fo.s3ref} from bucket ${s3_bucket}");
 
@@ -279,5 +271,36 @@ class FileUploadService {
     }
 
     return result;
+  }
+
+  /**
+   * Resolves the appropriate MinIO credentials provider based on the given access key and secret key.
+   * If both accessKey and secretKey are provided, a {@link StaticProvider} is returned.
+   * Otherwise, falls back to {@link IamAwsProvider} for IAM-based authentication (e.g. AWS instance roles).
+   *
+   * @param accessKey the S3/MinIO access key, may be null
+   * @param secretKey the S3/MinIO secret key, may be null
+   * @return a {@link Provider} instance to use for MinIO client authentication
+   */
+  protected static Provider resolveCredentialsProvider(String accessKey, String secretKey) {
+    if (accessKey && secretKey) {
+      return new StaticProvider(accessKey, secretKey, null)
+    } else {
+      return new IamAwsProvider(null, null)
+    }
+  }
+
+  /**
+   * Builds a {@link MinioClient} instance configured with the given endpoint and credentials provider.
+   *
+   * @param endpoint the S3/MinIO server endpoint URL
+   * @param provider the credentials provider to use for authentication
+   * @return a configured {@link MinioClient} instance
+   */
+  protected static MinioClient buildMinioClient(String endpoint, Provider provider) {
+    return MinioClient.builder()
+            .endpoint(endpoint)
+            .credentialsProvider(provider)
+            .build()
   }
 }

--- a/src/test/groovy/com/k_int/web/toolkit/files/FileUploadServiceSpec.groovy
+++ b/src/test/groovy/com/k_int/web/toolkit/files/FileUploadServiceSpec.groovy
@@ -1,0 +1,55 @@
+package com.k_int.web.toolkit.files
+
+import io.minio.MinioClient
+import io.minio.credentials.IamAwsProvider
+import io.minio.credentials.Provider
+import io.minio.credentials.StaticProvider
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class FileUploadServiceSpec extends Specification {
+
+  // ---- Provider selection tests ----
+
+  @Unroll
+  void 'resolveCredentialsProvider returns #expectedType when accessKey=#accessKey, secretKey=#secretKey'() {
+    when:
+      Provider provider = FileUploadService.resolveCredentialsProvider(accessKey, secretKey)
+
+    then:
+      expectedType.isInstance(provider)
+
+    where:
+      accessKey        | secretKey        || expectedType
+      'access'         | 'secret'         || StaticProvider      // both present → static
+      null             | null             || IamAwsProvider       // both null → IAM
+      null             | 'secret'         || IamAwsProvider       // access null → IAM
+      'access'         | null             || IamAwsProvider       // secret null → IAM
+      ''               | 'secret'         || IamAwsProvider       // access empty (Groovy falsy) → IAM
+      'access'         | ''               || IamAwsProvider       // secret empty (Groovy falsy) → IAM
+  }
+
+  // ---- MinioClient construction tests ----
+
+  void 'buildMinioClient creates a non-null client with StaticProvider'() {
+    given:
+      Provider provider = new StaticProvider('access', 'secret', null)
+
+    when:
+      MinioClient client = FileUploadService.buildMinioClient('http://localhost:9000', provider)
+
+    then:
+      client != null
+  }
+
+  void 'buildMinioClient creates a non-null client with IamAwsProvider'() {
+    given:
+      Provider provider = new IamAwsProvider(null, null)
+
+    when:
+      MinioClient client = FileUploadService.buildMinioClient('http://localhost:9000', provider)
+
+    then:
+      client != null
+  }
+}


### PR DESCRIPTION
[ERM-4000](https://folio-org.atlassian.net/browse/ERM-4000) - Web-toolkit - Support S3 access with implicit AWS role authorization

**Purpose:**
Use MinIO credentials provider for S3 authentication.

**Approach:**

1. Extracted credential resolution and MinIO client construction into reusable methods in FileUploadService. When both access key and secret key are configured, StaticProvider is used. Otherwise, falls back to IamAwsProvider for IAM-based auth. 
2. Updated both upload and download paths to use the new methods. 
3. Added unit tests.