### PR TITLE
ERM-3465. PUT/POST requests to /licenses/custprops accept characters that are illegal when submitted via UI

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -1,3 +1,4 @@
 
 # Custprop validation
+custprop.name.invalid=Custom property name must start with a letter and contain only letters, digits or underscores
 cannot.be.primary.and.retired=A custom property definition cannot be both primary and retired

--- a/src/integration-test/groovy/com/k_int/web/toolkit/custprops/CustomPropertiesSpec.groovy
+++ b/src/integration-test/groovy/com/k_int/web/toolkit/custprops/CustomPropertiesSpec.groovy
@@ -197,6 +197,133 @@ class CustomPropertiesSpec extends Specification {
       ids.contains(refdataThree)
   }
 
+  /////////////////////////// Name validation ///////////////////////////
+
+  @Transactional
+  def "Name validation accepts valid name '#validName'" (String validName) {
+    when: 'Creating a definition with a valid name'
+      CustomPropertyDefinition cpd = CustomPropertyDefinition.forType('Text', [
+        name: validName,
+        label: "Label ${validName}",
+        description: 'name-validation positive case',
+        primary: true
+      ])
+      def saved = cpd.save(flush: true)
+
+    then: 'Save succeeds and no errors are raised on name'
+      saved != null
+      !cpd.hasErrors()
+
+    where:
+      validName << [
+        'plainName',
+        'with_underscore',
+        'startsWithLetterThenDigits1',
+        '日本語Term',
+        'Юніт_тест',
+        'ÉlémentTest'
+      ]
+  }
+
+  @Transactional
+  def "Name validation rejects invalid name '#invalidName'" (String invalidName) {
+    when: 'Creating a definition with an invalid name'
+      CustomPropertyDefinition cpd = CustomPropertyDefinition.forType('Text', [
+        name: invalidName,
+        label: 'Label invalid case',
+        description: 'name-validation negative case',
+        primary: true
+      ])
+      def saved = cpd.save(flush: true)
+
+    then: 'Save fails with a validation error on the name field'
+      saved == null
+      cpd.hasErrors()
+      cpd.errors.getFieldError('name') != null
+
+    where:
+      invalidName << [
+        '1startsWithDigit',
+        'has.dot',
+        'has space',
+        'has-hyphen',
+        'has(paren',
+        'has,comma',
+        'has/slash',
+        'has#hash'
+      ]
+  }
+
+  @Transactional
+  def "Legacy row with a forbidden name can be updated without renaming" () {
+    given: 'A row persisted bypassing validation, simulating data created before the constraint existed'
+      CustomPropertyDefinition legacy = CustomPropertyDefinition.forType('Text', [
+        name: 'legacy.unmodified.name',
+        label: 'Legacy term',
+        description: 'original description',
+        primary: true
+      ])
+      legacy.save(flush: true, validate: false)
+      String legacyId = legacy.id
+
+    when: 'Reloading and updating only the description'
+      CustomPropertyDefinition reloaded = CustomPropertyDefinition.get(legacyId)
+      reloaded.description = 'updated description'
+      def saved = reloaded.save(flush: true)
+
+    then: 'Save succeeds because the validator is skipped when name is not dirty'
+      saved != null
+      !reloaded.hasErrors()
+      reloaded.description == 'updated description'
+      reloaded.name == 'legacy.unmodified.name'
+  }
+
+  @Transactional
+  def "Legacy row name cannot be changed to another forbidden value" () {
+    given: 'A row with a forbidden legacy name'
+      CustomPropertyDefinition legacy = CustomPropertyDefinition.forType('Text', [
+        name: 'legacy.rename.attempt',
+        label: 'Legacy term rename attempt',
+        description: 'desc',
+        primary: true
+      ])
+      legacy.save(flush: true, validate: false)
+      String legacyId = legacy.id
+
+    when: 'Changing the name to another invalid value'
+      CustomPropertyDefinition reloaded = CustomPropertyDefinition.get(legacyId)
+      reloaded.name = 'still.invalid'
+      def saved = reloaded.save(flush: true)
+
+    then: 'Validation fires because name is dirty and the new value also fails the rule'
+      saved == null
+      reloaded.hasErrors()
+      reloaded.errors.getFieldError('name') != null
+  }
+
+  @Transactional
+  def "Legacy row name can be migrated to a valid value" () {
+    given: 'A row with a forbidden legacy name'
+      CustomPropertyDefinition legacy = CustomPropertyDefinition.forType('Text', [
+        name: 'legacy.migrate.source',
+        label: 'Legacy term migrate',
+        description: 'desc',
+        primary: true
+      ])
+      legacy.save(flush: true, validate: false)
+      String legacyId = legacy.id
+
+    when: 'Renaming to a compliant value'
+      CustomPropertyDefinition reloaded = CustomPropertyDefinition.get(legacyId)
+      reloaded.name = 'cleanedUpName'
+      def saved = reloaded.save(flush: true)
+
+    then: 'Save succeeds'
+      saved != null
+      !reloaded.hasErrors()
+      reloaded.name == 'cleanedUpName'
+  }
+
   // CustomPropertyContainer is already tested via the above, nesting is _not_ tested currently
 }
 

--- a/src/main/groovy/com/k_int/web/toolkit/custprops/CustomPropertyDefinition.groovy
+++ b/src/main/groovy/com/k_int/web/toolkit/custprops/CustomPropertyDefinition.groovy
@@ -66,7 +66,7 @@ class CustomPropertyDefinition implements MultiTenant<CustomPropertyDefinition> 
     // and for loaded entities whose name has been modified, so legacy data is left untouched.
     name            (nullable: false, blank: false, unique: true, validator: { String val, CustomPropertyDefinition obj, Errors errors ->
       if (obj.hasChanged('name') && !(val ==~ /^\p{L}[\p{L}\p{N}_]*$/)) {
-        errors.rejectValue('name', 'matches.invalid')
+        errors.rejectValue('name', 'custprop.name.invalid')
       }
     })
     description     (nullable: true, blank: false)

--- a/src/main/groovy/com/k_int/web/toolkit/custprops/CustomPropertyDefinition.groovy
+++ b/src/main/groovy/com/k_int/web/toolkit/custprops/CustomPropertyDefinition.groovy
@@ -61,7 +61,8 @@ class CustomPropertyDefinition implements MultiTenant<CustomPropertyDefinition> 
 //  ]
   
   static constraints = {
-    name            (nullable: false, blank: false, unique: true)
+    // matches the stripes-kint-components UI validation rule for the same field.
+    name            (nullable: false, blank: false, unique: true, matches: /^[A-Za-z][A-Za-z0-9]*$/)
     description     (nullable: true, blank: false)
     type            (bindable: false, nullable: false)
     label           (nullable: false, blank: false)

--- a/src/main/groovy/com/k_int/web/toolkit/custprops/CustomPropertyDefinition.groovy
+++ b/src/main/groovy/com/k_int/web/toolkit/custprops/CustomPropertyDefinition.groovy
@@ -51,18 +51,24 @@ class CustomPropertyDefinition implements MultiTenant<CustomPropertyDefinition> 
       this.label = nameToLabel(this.name)
     }
   }
-  
+
 //  static hasMany = [
 //    propertyInstances: CustomProperty
 //  ]
-//  
+//
 //  static mappedBy = [
 //    propertyInstances: "definition"
 //  ]
-  
+
   static constraints = {
-    // matches the stripes-kint-components UI validation rule for the same field.
-    name            (nullable: false, blank: false, unique: true, matches: /^[A-Za-z][A-Za-z0-9]*$/)
+    // Restrict new/changed names to Unicode letters, digits and underscore (must start with a letter).
+    // Existing rows are grandfathered: hasChanged('name') returns true for new entities (no snapshot)
+    // and for loaded entities whose name has been modified, so legacy data is left untouched.
+    name            (nullable: false, blank: false, unique: true, validator: { String val, CustomPropertyDefinition obj, Errors errors ->
+      if (obj.hasChanged('name') && !(val ==~ /^\p{L}[\p{L}\p{N}_]*$/)) {
+        errors.rejectValue('name', 'matches.invalid')
+      }
+    })
     description     (nullable: true, blank: false)
     type            (bindable: false, nullable: false)
     label           (nullable: false, blank: false)


### PR DESCRIPTION
 ERM-3465: PUT/POST to /licenses/custprops accept characters illegal in UI

 What                                                                                                                                                                                                                             
   
Server-side validation for the name field of CustomPropertyDefinition. Allowed: any Unicode letter, then Unicode letters/digits/underscore. Regex: ^\p{L}[\p{L}\p{N}_]*$.                                                        
                  
Why a custom validator instead of matches:

  Two reviewer concerns: (1) tenants may already have rows with non-compliant names, (2) Latin-only would block Japanese, Cyrillic, etc. The validator solves both - Unicode regex covers (2), and a hasChanged('name') check
  covers (1).

  How the grandfather behavior works

  The validator only fires when hasChanged('name') is true:

  - New entity (POST): no DB snapshot → hasChanged is true → validate. Bad name rejected.
  - Existing entity, name unchanged (PUT of label/description/etc.): matches snapshot → hasChanged is false → skip. Legacy bad names stay editable.
  - Existing entity, name changed (PUT renaming): differs from snapshot → hasChanged is true → validate.

  No data migration needed. No extra DB queries - hasChanged is an in-memory comparison against the snapshot Hibernate already took when loading.
